### PR TITLE
Flag added to prevent potential image-processing race issu

### DIFF
--- a/CocoaHeads-CVML.xcodeproj/project.pbxproj
+++ b/CocoaHeads-CVML.xcodeproj/project.pbxproj
@@ -399,7 +399,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 74KPPW2K35;
+				DEVELOPMENT_TEAM = EK4EC97QFH;
 				INFOPLIST_FILE = "CocoaHeads-CVML/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -418,7 +418,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 74KPPW2K35;
+				DEVELOPMENT_TEAM = EK4EC97QFH;
 				INFOPLIST_FILE = "CocoaHeads-CVML/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Flag added in file ViewController that locks out attempts to process a frame while another is in the queue. Doing this locks out about 17 frames per image processed. 

The decision to put this in the view controller was that the processing step can be though of as a unit that lies in the ViewController, with the meat-and-potatoes processing residing in a different file, but is still a part of that processing unit. 